### PR TITLE
added variable name

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -9,3 +9,9 @@ variable "instance_type" {
   type        = string
   default     = "t2.micro"
 }
+
+variable "name" {
+  description = "Ec2 instance name"
+  type        = string
+  default = ""
+}


### PR DESCRIPTION
## Pull request summary created by Squire AI


[squire_summary_start]: #
### Summary

This pull request introduces a new variable 'name' in the 'terraform/variables.tf' file to define EC2 instance names. The default value for this variable is set to an empty string, allowing flexibility for future configurations. No other modifications have been made to existing configurations, ensuring backward compatibility.



92447cab0a46643cf468fa138544bea2c01e3d32...894e99d77177f4db03a64618aa24fdc2c4e49d11


[squire_summary_end]: #

[squire_changes_start]: #
### File Summary

#### File Changes:
* `variables.tf`: Added a new variable 'name' for EC2 instance name with a default empty string. No other changes made to existing configurations.



92447cab0a46643cf468fa138544bea2c01e3d32...894e99d77177f4db03a64618aa24fdc2c4e49d11


[squire_changes_end]: #
